### PR TITLE
[FEAT] create login api endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ repositories {
 }
 
 dependencies {
+	implementation "org.springframework.security:spring-security-web"
+	implementation "org.springframework.security:spring-security-config"
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/kyonggi/diet/auth/AuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/AuthController.java
@@ -8,14 +8,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class AuthController {
 
     private final MemberService memberService;

--- a/src/main/java/com/kyonggi/diet/auth/AuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/AuthController.java
@@ -1,0 +1,48 @@
+package com.kyonggi.diet.auth;
+
+import com.kyonggi.diet.member.MemberDTO;
+import com.kyonggi.diet.member.io.MemberRequest;
+import com.kyonggi.diet.member.io.MemberResponse;
+import com.kyonggi.diet.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final MemberService memberService;
+    private final ModelMapper modelMapper;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/register")
+    public MemberResponse register(@RequestBody MemberRequest memberRequest) {
+        log.info("API GET /register called");
+        MemberDTO memberDTO = mapToMemberDTO(memberRequest);
+        memberDTO = memberService.createMember(memberDTO);
+        log.info("Member DTO details {}", memberDTO);
+        return mapToMemberReponse(memberDTO);
+    }
+
+
+
+    /**
+     * MemberDTO 에서 MemberResponse 으로 변환하는 Mapper Method 입니다.
+     * @param memberDTO (member DTO)
+     * @return MemberResponse
+     */
+    private MemberResponse mapToMemberReponse(MemberDTO memberDTO) {
+        return modelMapper.map(memberDTO, MemberResponse.class);
+    }
+
+    private MemberDTO mapToMemberDTO(MemberRequest memberRequest) {
+        return modelMapper.map(memberRequest, MemberDTO.class);
+    }
+}

--- a/src/main/java/com/kyonggi/diet/auth/AuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/AuthController.java
@@ -1,14 +1,23 @@
 package com.kyonggi.diet.auth;
 
+import com.kyonggi.diet.auth.io.AuthRequest;
+import com.kyonggi.diet.auth.io.AuthResponse;
+import com.kyonggi.diet.auth.util.JwtTokenUtil;
 import com.kyonggi.diet.member.MemberDTO;
 import com.kyonggi.diet.member.io.MemberRequest;
 import com.kyonggi.diet.member.io.MemberResponse;
+import com.kyonggi.diet.member.service.CustomMembersDetailService;
 import com.kyonggi.diet.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @Slf4j
@@ -18,6 +27,9 @@ public class AuthController {
 
     private final MemberService memberService;
     private final ModelMapper modelMapper;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenUtil jwtTokenUtil;
+    private final CustomMembersDetailService membersDetailService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/register")
@@ -27,6 +39,15 @@ public class AuthController {
         memberDTO = memberService.createMember(memberDTO);
         log.info("Member DTO details {}", memberDTO);
         return mapToMemberReponse(memberDTO);
+    }
+
+    @PostMapping("/login")
+    public AuthResponse authenticateProfile(@RequestBody AuthRequest authRequest) {
+        log.info("API POST /login called");
+        authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(authRequest.getEmail(), authRequest.getPassword()));
+        final UserDetails user = membersDetailService.loadUserByUsername(authRequest.getEmail());
+        final String token = jwtTokenUtil.generateToken(user);
+        return new AuthResponse(token, authRequest.getEmail());
     }
 
 

--- a/src/main/java/com/kyonggi/diet/auth/config/CorsConfig.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.kyonggi.diet.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOriginPatterns(List.of("http://localhost:5173"));
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/kyonggi/diet/auth/config/JwtRequestFilter.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/JwtRequestFilter.java
@@ -1,18 +1,31 @@
 package com.kyonggi.diet.auth.config;
 
 import com.kyonggi.diet.auth.util.JwtTokenUtil;
+import com.kyonggi.diet.member.service.CustomMembersDetailService;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 public class JwtRequestFilter extends OncePerRequestFilter {
 
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") // I have to remove this and fix the error
+    @Autowired
     private JwtTokenUtil jwtTokenUtil;
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") // I have to remove this and fix the error
+    @Autowired
+    private CustomMembersDetailService membersDetailService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -31,7 +44,17 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             } catch (ExpiredJwtException ex) {
                 throw new RuntimeException("Jwt Token is expired", ex);
             }
-
         }
+
+        if(email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = membersDetailService.loadUserByUsername(email);
+
+            if(jwtTokenUtil.validateToken(jwtToken, userDetails)) {
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/kyonggi/diet/auth/config/JwtRequestFilter.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/JwtRequestFilter.java
@@ -1,0 +1,37 @@
+package com.kyonggi.diet.auth.config;
+
+import com.kyonggi.diet.auth.util.JwtTokenUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        final String authorizationHeader = request.getHeader("Authorization");
+
+        String jwtToken = null;
+        String email = null;
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            jwtToken = authorizationHeader.substring(7);
+
+            try {
+                email = jwtTokenUtil.getUsernameFromToken(jwtToken);
+            } catch (IllegalStateException ex) {
+                throw new RuntimeException("Unable to extract username from token", ex);
+            } catch (ExpiredJwtException ex) {
+                throw new RuntimeException("Jwt Token is expired", ex);
+            }
+
+        }
+    }
+}

--- a/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
@@ -24,7 +24,7 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity.csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(auth -> auth.requestMatchers("api/login", "api/member/register", "api/diet-content/dormitory").permitAll().anyRequest().authenticated())
+                .authorizeHttpRequests(auth -> auth.requestMatchers("api/login", "api/register", "api/diet-content/dormitory").permitAll().anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults())
                 .build();
     }

--- a/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
@@ -25,8 +25,15 @@ public class WebSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity.csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth.requestMatchers("api/login", "api/register", "api/diet-content/dormitory").permitAll().anyRequest().authenticated())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class)
                 .httpBasic(Customizer.withDefaults())
                 .build();
+    }
+
+    @Bean
+    public JwtRequestFilter authenticationJwtTokenFilter() {
+        return new JwtRequestFilter();
     }
 
     @Bean

--- a/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
@@ -1,0 +1,47 @@
+package com.kyonggi.diet.auth.config;
+
+import com.kyonggi.diet.member.service.CustomMembersDetailService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class WebSecurityConfig {
+
+    @Autowired
+    private CustomMembersDetailService customMembersDetailService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.requestMatchers("api/login", "api/member/register", "api/diet-content/dormitory").permitAll().anyRequest().authenticated())
+                .httpBasic(Customizer.withDefaults())
+                .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(customMembersDetailService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {return new BCryptPasswordEncoder();}
+}

--- a/src/main/java/com/kyonggi/diet/auth/io/AuthRequest.java
+++ b/src/main/java/com/kyonggi/diet/auth/io/AuthRequest.java
@@ -1,0 +1,15 @@
+package com.kyonggi.diet.auth.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AuthRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/kyonggi/diet/auth/io/AuthResponse.java
+++ b/src/main/java/com/kyonggi/diet/auth/io/AuthResponse.java
@@ -1,0 +1,11 @@
+package com.kyonggi.diet.auth.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthResponse {
+    private String token;
+    private String email;
+}

--- a/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
+++ b/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
@@ -27,7 +27,7 @@ public class JwtTokenUtil {
                 .setClaims(claims)
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY))
+                .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY * 1000))
                 .signWith(SignatureAlgorithm.HS256, secret)
                 .compact();
     }

--- a/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
+++ b/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
@@ -1,5 +1,6 @@
 package com.kyonggi.diet.auth.util;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,6 +11,7 @@ import javax.xml.crypto.Data;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 @Component
 public class JwtTokenUtil {
@@ -28,5 +30,14 @@ public class JwtTokenUtil {
                 .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY))
                 .signWith(SignatureAlgorithm.HS256, secret)
                 .compact();
+    }
+
+    public String getUsernameFromToken(String token) {
+        return getClaimFromToken(token, Claims::getSubject);
+    }
+
+    private <T> T getClaimFromToken(String token, Function<Claims, T> claimResolver) {
+        final Claims claims = Jwts.parserBuilder().setSigningKey(secret).build().parseClaimsJws(token).getBody();
+        return claimResolver.apply(claims);
     }
 }

--- a/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
+++ b/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
@@ -26,7 +26,7 @@ public class JwtTokenUtil {
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY))
-                .signWith(SignatureAlgorithm.HS512, secret)
+                .signWith(SignatureAlgorithm.HS256, secret)
                 .compact();
     }
 }

--- a/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
+++ b/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
@@ -1,0 +1,32 @@
+package com.kyonggi.diet.auth.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.xml.crypto.Data;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtTokenUtil {
+    private static final long JWT_TOKEN_VALIDITY = 5 * 60 * 60;
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    public String generateToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY))
+                .signWith(SignatureAlgorithm.HS512, secret)
+                .compact();
+    }
+}

--- a/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
+++ b/src/main/java/com/kyonggi/diet/auth/util/JwtTokenUtil.java
@@ -40,4 +40,14 @@ public class JwtTokenUtil {
         final Claims claims = Jwts.parserBuilder().setSigningKey(secret).build().parseClaimsJws(token).getBody();
         return claimResolver.apply(claims);
     }
+
+    public boolean validateToken(String token, UserDetails userDetails) {
+        final String email = getUsernameFromToken(token);
+        return email.equals(userDetails.getUsername()) && !isTokenExpired(token);
+    }
+
+    public boolean isTokenExpired(String token) {
+        final Date expiration = getClaimFromToken(token, Claims::getExpiration);
+        return expiration.before(new Date());
+    }
 }

--- a/src/main/java/com/kyonggi/diet/member/MemberController.java
+++ b/src/main/java/com/kyonggi/diet/member/MemberController.java
@@ -20,21 +20,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
 @Slf4j
-@CrossOrigin("*")
 public class MemberController {
 
     private final MemberService memberService;
     private final ModelMapper modelMapper;
-
-    @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/register")
-    public MemberResponse register(@RequestBody MemberRequest memberRequest) {
-        log.info("API GET /register called");
-        MemberDTO memberDTO = mapToMemberDTO(memberRequest);
-        memberDTO = memberService.createMember(memberDTO);
-        log.info("Member DTO details {}", memberDTO);
-        return mapToMemberReponse(memberDTO);
-    }
 
     /**
      * 모든 멤버 정보를 반환합니다.

--- a/src/main/java/com/kyonggi/diet/member/service/CustomMembersDetailService.java
+++ b/src/main/java/com/kyonggi/diet/member/service/CustomMembersDetailService.java
@@ -1,0 +1,30 @@
+package com.kyonggi.diet.member.service;
+
+import com.kyonggi.diet.member.MemberEntity;
+import com.kyonggi.diet.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CustomMembersDetailService implements UserDetailsService {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        MemberEntity memberEntity = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("Member not found for the email" + email));
+        return new User(memberEntity.getEmail(), memberEntity.getPassword(), new ArrayList<>());
+    }
+}

--- a/src/main/java/com/kyonggi/diet/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/kyonggi/diet/member/service/impl/MemberServiceImpl.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -28,14 +29,14 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final ModelMapper modelMapper;
+    private final PasswordEncoder encoder;
 
     @Override
     public MemberDTO createMember(MemberDTO memberDTO) {
         log.info("멤버 정보 Member DTO {}", memberDTO);
         //TODO: 중복된 계정 예외처리 추가
         //TODO: 비밀번호 인코드 과정 추가
-//        MemberEntity memberEntity = mapToMemberEntity(memberDTO);
-//        memberEntity.setMemberId(UUID.randomUUID().toString());
+        memberDTO.setPassword(encoder.encode(memberDTO.getPassword()));
         MemberEntity memberEntity = MemberEntity.builder()
                 .email(memberDTO.getEmail())
                 .password(memberDTO.getPassword())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,6 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+
+jwt:
+  secret: expensemanagersecretkeyexpensemanagersecretkey


### PR DESCRIPTION
# 🚨 ISSUE
#11 

# 🔨 CHANGES

### Dependency
- spring security
- jwt token

### Config
- create CORS config / 이제 컨트롤러에서`@CrossOrigin("*")` 를 사용하지 않아도 됩니다.
- create spring security config

### FEATURE
- create custom-member-detail-service / email을 통해 user를 반환하는 service
- auth controller / 기존 register api 해당 controller로 이동
- add password encoder / 이제 비밀번호를 encode 되어 암호화하여 db에 저장
- create method to generate jwt-token / jwt 토큰 발급하여 로그인시 반환 
- add jwt-filter to spring security / jwt filter 추가 api 요청시 헤더에서 토큰을 가져와 인증

# 🪜 ADDITIONAL CONTEXT
- **access token**만 발급하는 상황인데 추후 **refresh token**을 추가하여야 함
