### PR TITLE
[FEAT] 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'com.google.code.gson:gson:2.8.9'
 	implementation "org.springframework.security:spring-security-web"
 	implementation "org.springframework.security:spring-security-config"
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
@@ -1,12 +1,15 @@
 package com.kyonggi.diet.auth;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @RestController
 @Slf4j
@@ -16,13 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class KakaoAuthController {
 
     @Value("${kakao.client_id}")
-    private String client_id;
+    private String clientId;
 
     @Value("${kakao.redirect_uri}")
-    private String redirect_uri;
+    private String redirectUri;
 
     @GetMapping("/kakao-login")
-    public String login() {
-        return "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id="+client_id+"&redirect_uri="+redirect_uri;
+    public String kakaoLogin(@RequestParam(value="code", required = false) String code, HttpSession session, RedirectAttributes rttr) throws Exception {
+        log.info("#######{}", code);
+        String accessToken = kakaoAuthService.getAccessToken(code);
+        return kakaoAuthService.getUserInfo(accessToken, session, rttr);
     }
 }

--- a/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.view.RedirectView;
 
 @RestController
 @Slf4j
@@ -26,10 +27,13 @@ public class KakaoAuthController {
     @Value("${kakao.redirect_uri}")
     private String redirectUri;
 
-    @RequestMapping("/kakao-form")
-    public @ResponseBody String kakaoForm() {
-        return "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id="+clientId+"&redirect_uri="+redirectUri;
+    @GetMapping("/kakao-form")
+    public RedirectView kakaoForm() {
+        log.info("call kakao-form api");
+        String redirectUrl = "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=" + clientId + "&redirect_uri=" + redirectUri;
+        return new RedirectView(redirectUrl);
     }
+
 
     @GetMapping("/kakao-login")
     public AuthResponse kakaoLogin(@RequestParam(value="code", required = false) String code, HttpSession session, RedirectAttributes rttr) throws Exception {

--- a/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
@@ -1,5 +1,6 @@
 package com.kyonggi.diet.auth;
 
+import com.kyonggi.diet.auth.io.AuthResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -31,9 +32,11 @@ public class KakaoAuthController {
     }
 
     @GetMapping("/kakao-login")
-    public String kakaoLogin(@RequestParam(value="code", required = false) String code, HttpSession session, RedirectAttributes rttr) throws Exception {
+    public AuthResponse kakaoLogin(@RequestParam(value="code", required = false) String code, HttpSession session, RedirectAttributes rttr) throws Exception {
         log.info("#######{}", code);
         String accessToken = kakaoAuthService.getAccessToken(code);
-        return kakaoAuthService.getUserInfo(accessToken, session, rttr);
+        AuthResponse response = kakaoAuthService.getUserInfo(accessToken, session, rttr);
+        log.info("AuthResponse: {}", response); // AuthResponse 객체 확인
+        return response;
     }
 }

--- a/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
@@ -1,14 +1,12 @@
 package com.kyonggi.diet.auth;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @RestController
@@ -23,6 +21,11 @@ public class KakaoAuthController {
 
     @Value("${kakao.redirect_uri}")
     private String redirectUri;
+
+    @RequestMapping("/kakao-form")
+    public @ResponseBody String kakaoForm() {
+        return "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id="+clientId+"&redirect_uri="+redirectUri;
+    }
 
     @GetMapping("/kakao-login")
     public String kakaoLogin(@RequestParam(value="code", required = false) String code, HttpSession session, RedirectAttributes rttr) throws Exception {

--- a/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -16,7 +17,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Tag(name = "카카오 인증 API", description = "카카오 소셜 회원 인증(회원가입, 로그인 등)에 대한 API 입니다.")
 public class KakaoAuthController {
 
-    private KakaoAuthService kakaoAuthService;
+    final private KakaoAuthService kakaoAuthService;
 
     @Value("${kakao.client_id}")
     private String clientId;

--- a/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/KakaoAuthController.java
@@ -16,6 +16,8 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Tag(name = "카카오 인증 API", description = "카카오 소셜 회원 인증(회원가입, 로그인 등)에 대한 API 입니다.")
 public class KakaoAuthController {
 
+    private KakaoAuthService kakaoAuthService;
+
     @Value("${kakao.client_id}")
     private String clientId;
 

--- a/src/main/java/com/kyonggi/diet/auth/KakaoAuthService.java
+++ b/src/main/java/com/kyonggi/diet/auth/KakaoAuthService.java
@@ -1,13 +1,31 @@
 package com.kyonggi.diet.auth;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.kyonggi.diet.member.MemberDTO;
+import com.kyonggi.diet.member.MemberEntity;
+import com.kyonggi.diet.member.MemberRepository;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.parameters.P;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Optional;
 
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class KakaoAuthService {
+
+    private final MemberRepository memberRepository;
 
     public String getAccessToken(String authorizeCode) {
         String accessToken = "";
@@ -58,5 +76,74 @@ public class KakaoAuthService {
             e.printStackTrace();
         }
         return accessToken;
+    }
+
+    public String getUserInfo(String accessToken, HttpSession session, RedirectAttributes rttr) {
+        HashMap<String, Object> userInfo = new HashMap<>();
+        log.info("Called getUserInfo()");
+
+        String requestURL = "https://kapi.kakao.com/v2/user/me";
+        String view = null;
+        String msg = null;
+
+        try {
+            URL url = new URL(requestURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+
+            int responseCode = conn.getResponseCode(); //서버에서 보낸 http 상태코드 반환
+            System.out.println("responseCode :" + responseCode + "여긴가");
+            BufferedReader buffer = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            // 버퍼를 사용하여 읽은 것
+            String line = "";
+            String result = "";
+            while ((line = buffer.readLine()) != null) {
+                result += line;
+            }
+
+            System.out.println("response body :" + result);
+
+            // 읽었으니깐 데이터꺼내오기
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(result); //Json element 문자열변경
+            JsonObject properties = element.getAsJsonObject().get("properties").getAsJsonObject();
+            JsonObject kakao_account = element.getAsJsonObject().get("kakao_account").getAsJsonObject();
+
+            String nickname = properties.getAsJsonObject().get("nickname").getAsString();
+            String email = kakao_account.getAsJsonObject().get("email").getAsString();
+
+            //userInfo에 사용자 정보 저장
+            userInfo.put("email", email);
+            userInfo.put("nickname", nickname);
+
+            log.info(String.valueOf(userInfo));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // 이메일로 회원을 조회합니다.
+        Optional<MemberEntity> memberOpt = memberRepository.findByEmail((String) userInfo.get("email"));
+
+        MemberEntity member;
+        if (memberOpt.isEmpty()) {
+            // 회원이 없다면 새로 저장
+            member = MemberEntity.builder()
+                    .email((String) userInfo.get("email"))
+                    .name((String) userInfo.get("nickname"))
+                    .build();
+            memberRepository.save(member);
+            session.setAttribute("member", member);
+            view = "redirect:/";
+            msg = "회원가입 성공 및 로그인 완료";
+        } else {
+            // 기존 회원이라면 바로 로그인 처리
+            member = memberOpt.get();
+            session.setAttribute("member", member);
+            view = "redirect:/";
+            msg = "로그인 성공";
+        }
+        rttr.addFlashAttribute("msg", msg);
+        return view;
     }
 }

--- a/src/main/java/com/kyonggi/diet/auth/KakaoAuthService.java
+++ b/src/main/java/com/kyonggi/diet/auth/KakaoAuthService.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -27,6 +28,13 @@ public class KakaoAuthService {
 
     private final MemberRepository memberRepository;
 
+    @Value("${kakao.client_id}")
+    private String clientId;
+
+    @Value("${kakao.redirect_uri}")
+    private String redirectUri;
+
+
     public String getAccessToken(String authorizeCode) {
         String accessToken = "";
         String refreshToken = "";
@@ -43,8 +51,8 @@ public class KakaoAuthService {
             BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
             StringBuilder sb = new StringBuilder();
             sb.append("grant_type=authorization_code");
-            sb.append("&client_id=");  //발급받은 key
-            sb.append("&redirect_uri=");     // 본인이 설정해 놓은 redirect_uri 주소
+            sb.append("&client_id=").append(clientId);  //발급받은 key
+            sb.append("&redirect_uri=").append(redirectUri);     // 본인이 설정해 놓은 redirect_uri 주소
             sb.append("&code=").append(authorizeCode);
             bw.write(sb.toString());
             bw.flush();

--- a/src/main/java/com/kyonggi/diet/auth/KakaoAuthService.java
+++ b/src/main/java/com/kyonggi/diet/auth/KakaoAuthService.java
@@ -1,0 +1,62 @@
+package com.kyonggi.diet.auth;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class KakaoAuthService {
+
+    public String getAccessToken(String authorizeCode) {
+        String accessToken = "";
+        String refreshToken = "";
+        String requestUrl = "https://kauth.kakao.com/oauth/token";
+
+        try {
+            URL url = new URL(requestUrl);
+
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+
+            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
+            StringBuilder sb = new StringBuilder();
+            sb.append("grant_type=authorization_code");
+            sb.append("&client_id=");  //발급받은 key
+            sb.append("&redirect_uri=");     // 본인이 설정해 놓은 redirect_uri 주소
+            sb.append("&code=").append(authorizeCode);
+            bw.write(sb.toString());
+            bw.flush();
+
+            int responseCode = conn.getResponseCode();
+            System.out.println("responseCode : " + responseCode + "확인");
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            String result = "";
+
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+            System.out.println("response body : " + result + "결과");
+
+            JsonParser parser = new com.google.gson.JsonParser();
+            JsonElement element = parser.parse(result);
+
+            accessToken = element.getAsJsonObject().get("access_token").getAsString();
+            refreshToken = element.getAsJsonObject().get("refresh_token").getAsString();
+
+            System.out.println("access_token : " + accessToken);
+            System.out.println("refresh_token : " + refreshToken);
+
+            br.close();
+            bw.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return accessToken;
+    }
+}

--- a/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
@@ -24,7 +24,7 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity.csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(auth -> auth.requestMatchers("api/login", "api/register", "api/diet-content/dormitory","api/kakao-login" , "swagger-ui/**", "/v3/api-docs/**", "/health", "/", "/api/read-csv/*").permitAll().anyRequest().authenticated())
+                .authorizeHttpRequests(auth -> auth.requestMatchers("api/login", "api/register", "api/diet-content/dormitory", "api/kakao-form", "api/kakao-login" , "swagger-ui/**", "/v3/api-docs/**", "/health", "/", "/api/read-csv/*").permitAll().anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class)
                 .httpBasic(Customizer.withDefaults())

--- a/src/main/java/com/kyonggi/diet/auth/io/AuthResponse.java
+++ b/src/main/java/com/kyonggi/diet/auth/io/AuthResponse.java
@@ -14,4 +14,13 @@ public class AuthResponse {
 
     @Schema(description = "이메일")
     private String email;
+
+    @Override
+    public String toString() {
+        return "AuthResponse{" +
+                "token='" + token + '\'' +
+                ", email='" + email + '\'' +
+                '}';
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,4 +46,4 @@ cloud:
 
 kakao:
   client_id: ${REST_API_KEY}
-  redirect_uri: https://kiryong.site
+  redirect_uri: https://kiryong.site/api/kakao-login


### PR DESCRIPTION
# 🚨 ISSUE
#5 

# 🔨 CHANGES
카카오 로그인을 구현했습니다
- Kakao Auth Controller
- Kakao Auth Service

- kakao-form api로 요청시 자동으로 redirect됩니다.
- DB에 저장되어 있지 않다면 회원가입으로 정보를 DB에 저장합니다.
- DB에 저장되어 있다면 로그인으로 넘어갑니다.
- jwt token 발급 코드가 들어가있는데, 프론트에서 테스트 후 수정이 필요할 듯 합니다.

# 🪜 ADDITIONAL CONTEXT
