### PR TITLE
hotfix: fix http status code 500 to 404 for find each-member all api

### DIFF
--- a/src/main/java/com/kyonggi/diet/review/favoriteReview/controller/FavoriteDietFoodReviewController.java
+++ b/src/main/java/com/kyonggi/diet/review/favoriteReview/controller/FavoriteDietFoodReviewController.java
@@ -74,7 +74,7 @@ public class FavoriteDietFoodReviewController implements FavoriteDietFoodReviewC
             return ResponseEntity.ok(favoriteDietFoodReviewService.findFavoriteDietFoodReviewListByMember(email));
         } catch (Exception e) {
             log.error("Error processing token: ", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error fetching member reviews: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Error fetching member reviews: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/kyonggi/diet/review/favoriteReview/controller/FavoriteKyongsulFoodReviewController.java
+++ b/src/main/java/com/kyonggi/diet/review/favoriteReview/controller/FavoriteKyongsulFoodReviewController.java
@@ -69,7 +69,7 @@ public class FavoriteKyongsulFoodReviewController implements FavoriteKyongsulFoo
             return ResponseEntity.ok(favoriteKyongsulFoodReviewService.findFavoriteKyongsulFoodReviewListByMember(email));
         } catch (Exception e) {
             log.error("Error processing token: ", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error fetching member reviews: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Error fetching member reviews: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
# 🚨 ISSUE
멤버별 좋아요 누른 리뷰 조회 api 실패시 500으로 예외

# 🔨 CHANGES
500에서 404로 변경

# 🪜 ADDITIONAL CONTEXT
