### PR TITLE
fix: add cascade for favorite contents

### DIFF
--- a/src/main/java/com/kyonggi/diet/review/favoriteReview/domain/FavoriteDietFoodReview.java
+++ b/src/main/java/com/kyonggi/diet/review/favoriteReview/domain/FavoriteDietFoodReview.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.sql.Timestamp;
 
@@ -19,6 +21,10 @@ public class FavoriteDietFoodReview extends FavoriteReview{
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
-    @JoinColumn(name = "diet_food_review_id")
+    @JoinColumn(
+            name = "diet_food_review_id",
+            foreignKey = @ForeignKey(name = "fk_favorite_diet_food_review")
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private DietFoodReview dietFoodReview;
 }

--- a/src/main/java/com/kyonggi/diet/review/favoriteReview/domain/FavoriteESquareFoodReview.java
+++ b/src/main/java/com/kyonggi/diet/review/favoriteReview/domain/FavoriteESquareFoodReview.java
@@ -2,25 +2,29 @@ package com.kyonggi.diet.review.favoriteReview.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kyonggi.diet.review.domain.ESquareFoodReview;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
 @SuperBuilder
+@Table
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @AllArgsConstructor
 public class FavoriteESquareFoodReview extends FavoriteReview {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
-    @JoinColumn(name = "e_square_food_review_id")
+    @JoinColumn(
+            name = "e_square_food_review_id",
+            foreignKey = @ForeignKey(name = "fk_favorite_esquare_food_review")
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private ESquareFoodReview esquareFoodReview;
 }

--- a/src/main/java/com/kyonggi/diet/review/favoriteReview/domain/FavoriteKyongsulFoodReview.java
+++ b/src/main/java/com/kyonggi/diet/review/favoriteReview/domain/FavoriteKyongsulFoodReview.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.sql.Timestamp;
 
@@ -19,6 +21,10 @@ public class FavoriteKyongsulFoodReview extends FavoriteReview{
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
-    @JoinColumn(name = "kyongsul_food_review_id")
+    @JoinColumn(
+            name = "kyongsul_food_review_id",
+            foreignKey = @ForeignKey(name = "fk_favorite_kyongsul_food_review")
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private KyongsulFoodReview kyongsulFoodReview;
 }


### PR DESCRIPTION
# 🚨 ISSUE
리뷰 좋아요에 cascade가 없어 후에 문제 발생 가능성 존재

# 🔨 CHANGES
cascade 추가

# 🪜 ADDITIONAL CONTEXT
yml의 jpa update 방식으로는 기존 테이블 내의 fk는 변경이 안되므로, 수동 쿼리문으로 db 작업