### PR TITLE
fix: set and combo menu to other talbe

### DIFF
--- a/src/main/java/com/kyonggi/diet/Food/DTO/KyongsulSetFoodDTO.java
+++ b/src/main/java/com/kyonggi/diet/Food/DTO/KyongsulSetFoodDTO.java
@@ -1,0 +1,43 @@
+package com.kyonggi.diet.Food.DTO;
+
+import com.kyonggi.diet.Food.eumer.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KyongsulSetFoodDTO {
+
+    private Long id;
+
+    @Schema(description = "단품 음식 ID")
+    private Long baseFoodId;
+
+    @Schema(description = "세트 or 콤보")
+    private SetType setType;
+
+    @Schema(description = "경슐랭 음식 서브 식당")
+    private SubRestaurant subRestaurant;
+
+    @Schema(description = "경슐랭 음식 이름")
+    private String name;
+
+    @Schema(description = "경슐랭 음식 이름(영어)")
+    private String nameEn;
+
+    @Schema(description = "경슐랭 음식 가격")
+    private Long price;
+
+    /**
+     * ///////////
+     */
+
+    @Schema(description = "경슐랭 음식 카테고리(영어)")
+    private KyongsulCategory category;
+
+    @Schema(description = "경슐랭 음식 카테고리(한국어)")
+    private String categoryKorean;
+}

--- a/src/main/java/com/kyonggi/diet/Food/controller/FoodController.java
+++ b/src/main/java/com/kyonggi/diet/Food/controller/FoodController.java
@@ -10,7 +10,6 @@ import com.kyonggi.diet.Food.service.ESquareFoodService;
 import com.kyonggi.diet.Food.service.KyongsulFoodService;
 import com.kyonggi.diet.Food.service.SallyBoxFoodService;
 import com.kyonggi.diet.controllerDocs.FoodControllerDocs;
-import com.kyonggi.diet.review.DTO.FoodNamesDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -239,4 +238,50 @@ public class FoodController implements FoodControllerDocs {
         }
     }
 
+    @GetMapping("/{type}/sets-one/{foodId}")
+    public ResponseEntity<?> getSetsFoodById(
+            @PathVariable RestaurantType type,
+            @PathVariable Long foodId
+    ) {
+        try {
+            Object result = switch (type) {
+                case KYONGSUL -> kyongsulFoodService.findOneSetDTO(foodId);
+
+                default -> null;
+            };
+
+            if (result == null) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body("Invalid restaurant type or no data: " + type);
+            }
+            return ResponseEntity.ok(Map.of("result", result));
+
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+
+
+    @GetMapping("/{type}/get-sets/{baseFoodId}")
+    public ResponseEntity<?> findSetsByBaseFoodId(
+            @PathVariable RestaurantType type,
+            @PathVariable Long baseFoodId
+    ) {
+        try {
+            Object result = switch (type) {
+                case KYONGSUL -> kyongsulFoodService.findByBaseFood(baseFoodId);
+                default -> null;
+            };
+
+            if (result == null) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid restaurant type: " + type);
+            }
+
+            Map<String, Object> response = Map.of("result", result);
+            return ResponseEntity.ok(response);
+        } catch (NotFoundException e) {
+            return ResponseEntity.ok(Map.of("result", List.of()));
+        }
+    }
 }

--- a/src/main/java/com/kyonggi/diet/Food/domain/KyongsulFood.java
+++ b/src/main/java/com/kyonggi/diet/Food/domain/KyongsulFood.java
@@ -31,6 +31,12 @@ public class KyongsulFood extends ExtendedFood {
     @Column(name = "category_kr")
     private String categoryKorean;
 
+    @OneToMany(
+            mappedBy = "baseFood",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    private List<KyongsulSetFood> foodSets;
 
     @OneToMany(
             mappedBy = "kyongsulFood",

--- a/src/main/java/com/kyonggi/diet/Food/domain/KyongsulSetFood.java
+++ b/src/main/java/com/kyonggi/diet/Food/domain/KyongsulSetFood.java
@@ -1,0 +1,42 @@
+package com.kyonggi.diet.Food.domain;
+
+import com.kyonggi.diet.Food.eumer.KyongsulCategory;
+import com.kyonggi.diet.Food.eumer.SetType;
+import com.kyonggi.diet.Food.eumer.SubRestaurant;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
+public class KyongsulSetFood extends Food {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "kyongsul_food_set_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private SetType setType;  // SET / COMBO
+
+    @Enumerated(EnumType.STRING)
+    private SubRestaurant subRestaurant;
+
+    @Enumerated(EnumType.STRING)
+    private KyongsulCategory category;
+
+    @Column(name = "category_kr")
+    private String categoryKorean;
+
+    private Long price;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+        name = "base_food_id",
+        foreignKey = @ForeignKey(name = "fk_foodset_base_food")
+    )
+    private KyongsulFood baseFood;
+}

--- a/src/main/java/com/kyonggi/diet/Food/eumer/SetType.java
+++ b/src/main/java/com/kyonggi/diet/Food/eumer/SetType.java
@@ -1,0 +1,13 @@
+package com.kyonggi.diet.Food.eumer;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SetType {
+    SET("세트"),
+    COMBO("콤보");
+
+    private final String koreanName;
+}

--- a/src/main/java/com/kyonggi/diet/Food/repository/KyongsulSetFoodRepository.java
+++ b/src/main/java/com/kyonggi/diet/Food/repository/KyongsulSetFoodRepository.java
@@ -1,0 +1,17 @@
+package com.kyonggi.diet.Food.repository;
+
+import com.kyonggi.diet.Food.domain.KyongsulSetFood;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface KyongsulSetFoodRepository extends JpaRepository<KyongsulSetFood,Long> {
+
+    @Query("select k from KyongsulSetFood k where k.baseFood.id = :baseFoodId")
+    List<KyongsulSetFood> findAllByBaseFoodId(@Param("baseFoodId") Long baseFoodId);
+
+    Optional<KyongsulSetFood> findByName(String name);
+}

--- a/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
@@ -43,7 +43,7 @@ public class WebSecurityConfig {
                                 // Food API
                                 "/api/food/*/*", "/api/food/KYONGSUL/restaurant/*", "api/food/*/get-names/*",
                                 "/api/read-csv/*", "/api/food/*/each-category", "/api/food/top5-menu",
-                                "/api/food/*/category/*",
+                                "/api/food/*/category/*", "/api/food/*/get-sets/*", "/api/food/*/sets-one/*",
 
                                 // Review API
                                 "/api/review/*/reviews/top5-rating","/api/review/*/reviews/top5-recent",

--- a/src/main/java/com/kyonggi/diet/controllerDocs/FoodControllerDocs.java
+++ b/src/main/java/com/kyonggi/diet/controllerDocs/FoodControllerDocs.java
@@ -5,7 +5,13 @@ import com.kyonggi.diet.Food.eumer.SubRestaurant;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 public interface FoodControllerDocs {
 
@@ -99,4 +105,54 @@ public interface FoodControllerDocs {
             description = "경슐랭, 이스퀘어, 샐리박스 전체 식당을 통합하여 리뷰 개수가 가장 많은 음식 5개를 반환합니다. 경슐랭 이외의 조회 경우 SubRestaurant는 null값"
     )
     ResponseEntity<?> getTop5Food();
+
+    // ---------------------- 세트/콤보 테이블 내 음식 조회 -------------------------
+    @Operation(
+            summary = "세트/콤보 테이블 내 음식 조회",
+            description = "세트/콤보 테이블 내에 존재하는 음식의 id 값으로 음식에 대한 정보를 조회합니다."
+    )
+    ResponseEntity<?> getSetsFoodById(
+            @Parameter(
+                    name = "type",
+                    description = "식당 종류 (현재: KYONGSUL만 지원)",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            @PathVariable RestaurantType type,
+
+            @Parameter(
+                    name = "foodId",
+                    description = "조회할 세트/콤보 음식 ID",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            @PathVariable Long foodId
+    );
+
+
+    @Operation(
+            summary = "단품의 하위 메뉴(세트/콤보) 조회",
+            description = """
+                    **🚨 현재 경슐랭 식당만 활성화된 상태입니다.**  
+                    - 해당 음식 id에 대한 하위 메뉴가 없을 경우 빈 리스트 반환  
+                    - 존재할 경우 세트/콤보 정보 목록 반환
+                    """
+    )
+    ResponseEntity<?> findSetsByBaseFoodId(
+            @Parameter(
+                    name = "type",
+                    description = "식당 종류 (현재: KYONGSUL만 지원)",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            @PathVariable RestaurantType type,
+
+            @Parameter(
+                    name = "baseFoodId",
+                    description = "단품 음식 ID (이 단품을 기준으로 세트/콤보를 조회)",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            @PathVariable Long baseFoodId
+    );
 }

--- a/src/main/java/com/kyonggi/diet/dietFile/CSVController.java
+++ b/src/main/java/com/kyonggi/diet/dietFile/CSVController.java
@@ -31,6 +31,13 @@ public class CSVController implements CSVControllerDocs {
         csvReader.readKyongsulCSVFile(keyDTO.getKey());
     }
 
+    @PostMapping("kyongsul-set")
+    public void readKyongsulSet(@RequestBody KeyDTO keyDTO) throws CsvValidationException, IOException {
+        if(keyDTO.getKey() == null)
+            return;
+        csvReader.readKyongsulSetCSVFile(keyDTO.getKey());
+    }
+
     @PostMapping("/e-square")
     public void readESquare(@RequestBody KeyDTO keyDTO) throws CsvValidationException, IOException {
         if(keyDTO.getKey() == null)


### PR DESCRIPTION
# 🚨 ISSUE
세트 및 콤보 메뉴들이 단품이 존재해도 보임

# 🔨 CHANGES
해당 메뉴들을 다른 테이블로 옮기고, 단품에 해당하는 id 값으로 정보들을 확인할 수 있게 변경
- 새로운 테이블 내 음식 id로 음식 상세 정보 확인 가능(콤보 및 세트)
- 단품 id 값으로, 하위 메뉴들 조회 가능

# 🪜 ADDITIONAL CONTEXT
s3에 해당 csv 저장