### PR TITLE
fix: remove set and combo category from original category type

### DIFF
--- a/src/main/java/com/kyonggi/diet/Food/eumer/KyongsulCategory.java
+++ b/src/main/java/com/kyonggi/diet/Food/eumer/KyongsulCategory.java
@@ -27,8 +27,6 @@ public enum KyongsulCategory {
     TTEOKBOKKI("떡볶이"), //버거&타코도
 
     // 버거&타코
-    SET("세트"),
-    COMBO("콤보"),
     TACO("타코"),
     BURGER("버거"),
     CHICKEN("치킨"),


### PR DESCRIPTION
# 🚨 ISSUE
기존에 세트, 콤보 카테고리 및 메뉴가 존재

# 🔨 CHANGES
- 이전 테이블에 있던 세트, 콤보 삭제 및 enum 타입에서 제외

# 🪜 ADDITIONAL CONTEXT
