### PR TITLE
fix: fix kakao redirect uri

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,7 +99,7 @@ cloud:
 
 kakao:
   client_id: ${REST_API_KEY}
-  redirect_uri: https://www.kiryong.kr/auth
+  redirect_uri: ${KAKAO_REDIRECT_URI}
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
# 🚨 ISSUE
카카오 리다렉 uri yml 파일에 계속 존재 (타 소셜 로그인과 통일 필요)

# 🔨 CHANGES
환경변수화 완료
# 🪜 ADDITIONAL CONTEXT
