### PR TITLE
feat: add apple revoke function

### DIFF
--- a/src/main/java/com/kyonggi/diet/auth/Provider.java
+++ b/src/main/java/com/kyonggi/diet/auth/Provider.java
@@ -1,0 +1,14 @@
+package com.kyonggi.diet.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Provider {
+    KAKAO("카카오"),
+    GOOGLE("구글"),
+    APPLE("애플");
+
+    private final String name;
+}

--- a/src/main/java/com/kyonggi/diet/auth/apple/AppleAuthController.java
+++ b/src/main/java/com/kyonggi/diet/auth/apple/AppleAuthController.java
@@ -3,10 +3,12 @@ package com.kyonggi.diet.auth.apple;
 import com.kyonggi.diet.auth.apple.service.AppleLoginService;
 import com.kyonggi.diet.auth.apple.service.AppleOAuthClient;
 import com.kyonggi.diet.auth.io.AuthResponse;
+import com.kyonggi.diet.auth.util.JwtTokenUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -64,5 +66,15 @@ public class AppleAuthController {
         AuthResponse response = appleLoginService.appleLogin(code, userJson, storedNonce);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/apple-revoke")
+    public ResponseEntity<?> revoke(@RequestHeader("Authorization") String token) {
+        try {
+            appleLoginService.revoke(token);
+            return ResponseEntity.ok("Revoked");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/kyonggi/diet/auth/apple/dto/AppleDto.java
+++ b/src/main/java/com/kyonggi/diet/auth/apple/dto/AppleDto.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @Data
 public class AppleDto {
     private String sub; //apple sub
-    private String token; //access token
+    private String access_token; //access token
+    private String refresh_token; //refresh_token
     private String email;
 }

--- a/src/main/java/com/kyonggi/diet/auth/apple/service/AppleLoginService.java
+++ b/src/main/java/com/kyonggi/diet/auth/apple/service/AppleLoginService.java
@@ -8,6 +8,8 @@ import com.kyonggi.diet.member.MemberRepository;
 import com.kyonggi.diet.member.service.CustomMembersDetailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,14 +22,14 @@ public class AppleLoginService {
     private final MemberRepository memberRepository;
     private final CustomMembersDetailService customMembersDetailService;
     private final JwtTokenUtil jwtTokenUtil;
-
+    private final StringRedisTemplate redisTemplate;
 
     public AuthResponse appleLogin(String code, String userJson, String expectedNonce) throws Exception {
         AppleDto appleDto = appleOAuthClient.getAppleInfo(code, expectedNonce);
         String name = appleOAuthClient.extractNameFromUser(userJson);
 
         MemberEntity member = memberRepository.findByEmail(appleDto.getEmail())
-                .orElseGet(() -> memberRepository.save(
+                .orElseGet(() -> memberRepository.saveAndFlush(
                         MemberEntity.builder()
                                 .email(appleDto.getEmail())
                                 .appleSub(appleDto.getSub())
@@ -35,10 +37,26 @@ public class AppleLoginService {
                                 .build()
                 ));
 
+        appleOAuthClient.saveOrUpdateRefreshToken(member, appleDto.getRefresh_token());
+
         String jwt = jwtTokenUtil.generateToken(
                 customMembersDetailService.loadUserByUsername(member.getEmail())
         );
 
-        return new AuthResponse(member.getEmail(), jwt);
+        return new AuthResponse(jwt, appleDto.getEmail());
+    }
+
+    public void revoke(String authorizationHeader) {
+        String jwt = authorizationHeader.substring(7);
+        String email = jwtTokenUtil.getUsernameFromToken(jwt);
+
+        MemberEntity member = memberRepository.findByEmail(email)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("Member not found: " + email)
+                );
+        // 1. Apple revoke
+        appleOAuthClient.userRevoke(member);
+        // 2. 회원 삭제 (RefreshToken은 CASCADE)
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/com/kyonggi/diet/auth/socialRefresh/SocialRefreshToken.java
+++ b/src/main/java/com/kyonggi/diet/auth/socialRefresh/SocialRefreshToken.java
@@ -1,0 +1,38 @@
+package com.kyonggi.diet.auth.socialRefresh;
+
+import com.kyonggi.diet.auth.Provider;
+import com.kyonggi.diet.member.MemberEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Table
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SocialRefreshToken {
+    @Id @Column(name = "member_id")
+    private Long memberId;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "member_id",
+            foreignKey = @ForeignKey(name = "fk_member_social_refresh")
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private MemberEntity member;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private Provider provider;
+
+    private String refreshToken;
+
+    public void updateRefreshToken(String refreshTokenValue) {
+        this.refreshToken = refreshTokenValue;
+    }
+}

--- a/src/main/java/com/kyonggi/diet/auth/socialRefresh/SocialRefreshTokenRepository.java
+++ b/src/main/java/com/kyonggi/diet/auth/socialRefresh/SocialRefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.kyonggi.diet.auth.socialRefresh;
+
+import com.kyonggi.diet.auth.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SocialRefreshTokenRepository extends JpaRepository<SocialRefreshToken, Long> {
+
+    Optional<SocialRefreshToken> findByMemberId(Long memberId);
+
+    Optional<SocialRefreshToken> findByProvider(Provider provider);
+}

--- a/src/main/java/com/kyonggi/diet/member/MemberEntity.java
+++ b/src/main/java/com/kyonggi/diet/member/MemberEntity.java
@@ -1,5 +1,6 @@
 package com.kyonggi.diet.member;
 
+import com.kyonggi.diet.auth.socialRefresh.SocialRefreshToken;
 import com.kyonggi.diet.review.domain.DietFoodReview;
 import com.kyonggi.diet.review.domain.ESquareFoodReview;
 import com.kyonggi.diet.review.domain.KyongsulFoodReview;
@@ -72,5 +73,8 @@ public class MemberEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FavoriteSallyBoxFoodReview> favoriteSallyBoxFoodReviews;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private SocialRefreshToken socialRefreshToken;
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,8 @@ spring:
 
   data:
     redis:
-      host: ${SPRING_REDIS_HOST}
+      host: ${SPRING_REDIS_HOST} #배포용
+      #host: localhost #테스트
       port: ${SPRING_REDIS_PORT}
       timeout: 2000ms
 


### PR DESCRIPTION
# 🚨 ISSUE
#146 

# 🔨 CHANGES
- 애플 소셜 로그인 탈퇴 구현
- 소셜 로그인 탈퇴를 위한 리프레시 저장 테이블 생성 (그 우리가 미래에 쓸 그 리프레시 X. 애플에서 이런 곳에 쓰라고 준 리프레시 토큰임)

# 🪜 ADDITIONAL CONTEXT
