### PR TITLE
feat: add withDraw Reason service

### DIFF
--- a/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
@@ -60,8 +60,11 @@ public class WebSecurityConfig {
                                 // Diet Content API
                                 "/api/diet-content/dormitory/dow/*", "api/diet-content/dormitory",
 
-                                // Search
-                                "/api/search/**"
+                                // Search API
+                                "/api/search/**",
+
+                                // Withdraw API
+                                "/api/withdraw/etcs", "/api/withdraw/reasons", "/api/withdraw/each-count"
                                  ).permitAll().anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/kyonggi/diet/auth/withDrawReason/WithDrawReasonController.java
+++ b/src/main/java/com/kyonggi/diet/auth/withDrawReason/WithDrawReasonController.java
@@ -1,0 +1,116 @@
+package com.kyonggi.diet.auth.withDrawReason;
+
+import com.kyonggi.diet.auth.withDrawReason.domain.WithDrawReasonType;
+import com.kyonggi.diet.auth.withDrawReason.dto.WithDrawReasonDto;
+import com.kyonggi.diet.auth.withDrawReason.dto.WithDrawReasonEtcRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/withdraw")
+@Slf4j
+@Tag(
+    name = "탈퇴 사유 설문 API",
+    description = "회원 탈퇴 사유 설문 및 통계 API"
+)
+public class WithDrawReasonController {
+
+    private final WithDrawReasonService withDrawReasonService;
+
+    @Operation(
+        summary = "탈퇴 사유 목록 조회",
+        description = "회원 탈퇴 시 선택할 수 있는 모든 탈퇴 사유(enum)와 설명을 조회합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "탈퇴 사유 목록 조회 성공")
+    })
+    @GetMapping("/reasons")
+    public ResponseEntity<?> getWithdrawReasons() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("result", withDrawReasonService.getAllReasonTypes());
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(
+        summary = "탈퇴 사유 타입별 카운트 조회",
+        description = "모든 탈퇴 사유 타입(enum)에 대해 탈퇴 건수를 조회합니다. 데이터가 없는 타입은 0으로 반환됩니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "탈퇴 사유 타입별 통계 조회 성공")
+    })
+    @GetMapping("/each-count")
+    public ResponseEntity<?> getEachCount() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("result", withDrawReasonService.getWithDrawReasonCountByEachType());
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(
+        summary = "기타(ETC) 탈퇴 사유 상세 조회",
+        description = "기타(ETC)로 입력된 모든 탈퇴 사유 텍스트를 조회합니다. (데이터 분석용)"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "기타 탈퇴 사유 조회 성공")
+    })
+    @GetMapping("/etcs")
+    public ResponseEntity<?> getEtcs() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("result", withDrawReasonService.getEtcReasons());
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(
+        summary = "탈퇴 사유 등록",
+        description = """
+            회원 탈퇴 시 선택한 탈퇴 사유를 저장합니다.
+            
+            - 로그인된 사용자만 호출 가능합니다.
+            - 탈퇴 사유가 ETC인 경우, 기타 사유 텍스트 입력은 필수입니다.
+            - 기타 사유 필수인 부분은 프론트에서 막아주세요.
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "탈퇴 사유 저장 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 검증 실패"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @PostMapping("/create/{type}")
+    public ResponseEntity<?> createWithDrawReason(
+            @PathVariable("type") WithDrawReasonType type,
+            @RequestBody(required = false) WithDrawReasonEtcRequest reason
+    ) {
+        try {
+            // ETC가 아닌데 기타 사유가 들어온 경우 차단
+            if (type != WithDrawReasonType.ETC
+                    && reason != null
+                    && reason.getEtcReason() != null) {
+                return ResponseEntity.badRequest()
+                        .body("ETC가 아닌 탈퇴 사유에는 기타 사유를 입력할 수 없습니다.");
+            }
+
+            WithDrawReasonDto dto = WithDrawReasonDto.builder()
+                    .type(type)
+                    .build();
+
+            if (reason != null) {
+                dto.setEtcReason(reason.getEtcReason());
+            }
+
+            withDrawReasonService.save(dto);
+            return ResponseEntity.ok().build();
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/kyonggi/diet/auth/withDrawReason/WithDrawReasonRepository.java
+++ b/src/main/java/com/kyonggi/diet/auth/withDrawReason/WithDrawReasonRepository.java
@@ -1,0 +1,19 @@
+package com.kyonggi.diet.auth.withDrawReason;
+
+import com.kyonggi.diet.auth.withDrawReason.domain.WithDrawReason;
+import com.kyonggi.diet.auth.withDrawReason.domain.WithDrawReasonType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface WithDrawReasonRepository extends JpaRepository<WithDrawReason, Long> {
+    @Query("""
+    select w.type, count(w)
+    from WithDrawReason w
+    group by w.type
+    """)
+    List<Object[]> countGroupByType();
+
+    List<WithDrawReason> findByType(WithDrawReasonType type);
+}

--- a/src/main/java/com/kyonggi/diet/auth/withDrawReason/WithDrawReasonService.java
+++ b/src/main/java/com/kyonggi/diet/auth/withDrawReason/WithDrawReasonService.java
@@ -1,0 +1,88 @@
+package com.kyonggi.diet.auth.withDrawReason;
+
+import com.kyonggi.diet.auth.withDrawReason.domain.WithDrawReason;
+import com.kyonggi.diet.auth.withDrawReason.domain.WithDrawReasonType;
+import com.kyonggi.diet.auth.withDrawReason.dto.WithDrawReasonDto;
+import com.kyonggi.diet.auth.withDrawReason.dto.WithDrawReasonTypeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WithDrawReasonService {
+
+    private final WithDrawReasonRepository withDrawReasonRepository;
+
+    /**
+     * 탈퇴 사유 등록
+     */
+    @Transactional
+    public Long save(WithDrawReasonDto dto) {
+        if (dto.getType() == WithDrawReasonType.ETC &&
+                (dto.getEtcReason() == null || dto.getEtcReason().isBlank())) {
+            throw new IllegalArgumentException("기타 사유는 내용을 입력해야 합니다.");
+        }
+        WithDrawReason entity = WithDrawReason.builder()
+                .type(dto.getType())
+                .etcReason(dto.getEtcReason())
+                .build();
+
+        WithDrawReason saved = withDrawReasonRepository.save(entity);
+        return saved.getId();
+    }
+
+    /**
+     * 탈퇴 사유 enum 목록 조회
+     */
+    public List<WithDrawReasonTypeResponse> getAllReasonTypes() {
+        return Arrays.stream(WithDrawReasonType.values())
+                .map(type -> new WithDrawReasonTypeResponse(
+                        type.name(),
+                        type.getDescription()
+                ))
+                .toList();
+    }
+
+    /**
+     * 각 탈퇴 사유별 카운팅
+     */
+    public Map<String, Long> getWithDrawReasonCountByEachType() {
+
+        Map<WithDrawReasonType, Long> result = new EnumMap<>(WithDrawReasonType.class);
+        for (WithDrawReasonType type : WithDrawReasonType.values()) {
+            result.put(type, 0L);
+        }
+
+        List<Object[]> counts = withDrawReasonRepository.countGroupByType();
+        for (Object[] row : counts) {
+            WithDrawReasonType type = (WithDrawReasonType) row[0];
+            Long count = (Long) row[1];
+            result.put(type, count);
+        }
+
+        return result.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> e.getKey().name(),
+                        Map.Entry::getValue
+                ));
+    }
+
+
+    /**
+     * 탈퇴 사유가 기타인 내용 리스트 출력
+     */
+    public List<String> getEtcReasons() {
+        return withDrawReasonRepository.findByType(WithDrawReasonType.ETC)
+                .stream()
+                .map(WithDrawReason::getEtcReason)
+                .toList();
+    }
+}

--- a/src/main/java/com/kyonggi/diet/auth/withDrawReason/domain/WithDrawReason.java
+++ b/src/main/java/com/kyonggi/diet/auth/withDrawReason/domain/WithDrawReason.java
@@ -1,0 +1,26 @@
+package com.kyonggi.diet.auth.withDrawReason.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class WithDrawReason {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private WithDrawReasonType type;
+
+    @Column(length = 500)
+    private String etcReason;
+}

--- a/src/main/java/com/kyonggi/diet/auth/withDrawReason/domain/WithDrawReasonType.java
+++ b/src/main/java/com/kyonggi/diet/auth/withDrawReason/domain/WithDrawReasonType.java
@@ -1,0 +1,16 @@
+package com.kyonggi.diet.auth.withDrawReason.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WithDrawReasonType {
+    NO_NEED_RESTAURANT("더 이상 식당 정보가 필요하지 않아요"),
+    MENU_SEARCH_DIFFICULT("메뉴를 찾는 과정이 불편해요"),
+    COMMENT_DIFFICULT("댓글 작성이 불편해요"),
+    OFFENSIVE_COMMENTS("불쾌한 댓글이 많아요"),
+    ETC("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/kyonggi/diet/auth/withDrawReason/dto/WithDrawReasonDto.java
+++ b/src/main/java/com/kyonggi/diet/auth/withDrawReason/dto/WithDrawReasonDto.java
@@ -1,0 +1,13 @@
+package com.kyonggi.diet.auth.withDrawReason.dto;
+
+import com.kyonggi.diet.auth.withDrawReason.domain.WithDrawReasonType;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WithDrawReasonDto {
+    private WithDrawReasonType type;
+    private String etcReason;
+}

--- a/src/main/java/com/kyonggi/diet/auth/withDrawReason/dto/WithDrawReasonEtcRequest.java
+++ b/src/main/java/com/kyonggi/diet/auth/withDrawReason/dto/WithDrawReasonEtcRequest.java
@@ -1,0 +1,15 @@
+package com.kyonggi.diet.auth.withDrawReason.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "기타 탈퇴 사유 입력 DTO")
+public class WithDrawReasonEtcRequest {
+    @Schema(
+        description = "기타(ETC) 선택 시 입력하는 탈퇴 사유"
+    )
+    private String etcReason;
+}

--- a/src/main/java/com/kyonggi/diet/auth/withDrawReason/dto/WithDrawReasonTypeResponse.java
+++ b/src/main/java/com/kyonggi/diet/auth/withDrawReason/dto/WithDrawReasonTypeResponse.java
@@ -1,0 +1,11 @@
+package com.kyonggi.diet.auth.withDrawReason.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WithDrawReasonTypeResponse {
+    private String type;
+    private String description;
+}


### PR DESCRIPTION
# 🚨 ISSUE
#146 

# 🔨 CHANGES
- 회원 탈퇴 시 설문조사 추가
- 설문 테이블 생성(id, 탈퇴사유, etcReason)
- etcReason의 경우 탈퇴 사유가 ETC 인 경우에만 값 존재. ( Nullable)

API 목록
- 탈퇴 사유 등록
- 탈퇴 사유 목록 조회 (프론트에 사유 목록 띄울 떄)
- 탈퇴 사유별 카운트 조회
- ETC(기타) 목록 리스트 조회

# 🪜 ADDITIONAL CONTEXT
