### PR TITLE
fix: add nickname column to memberEntity

### DIFF
--- a/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/kyonggi/diet/auth/config/WebSecurityConfig.java
@@ -41,7 +41,7 @@ public class WebSecurityConfig {
                                 // Auth API
                                 "/api/login", "api/register", "/api/kakao-form",
                                 "/api/kakao-login/**", "/api/google-form", "/api/google-login/**", "/api/oauth2/google/**",
-                                 "/auth", "/api/apple-login","/api/apple-form",
+                                 "/auth", "/api/apple-login","/api/apple-form","/api/member/nickname/check",
                                 // Swagger API
                                 "swagger-ui/**", "/v3/api-docs/**",
 

--- a/src/main/java/com/kyonggi/diet/controllerDocs/MemberControllerDocs.java
+++ b/src/main/java/com/kyonggi/diet/controllerDocs/MemberControllerDocs.java
@@ -1,14 +1,17 @@
 package com.kyonggi.diet.controllerDocs;
 
+import com.kyonggi.diet.member.CustomUserDetails;
+import com.kyonggi.diet.member.DTO.UpdateNicknameRequest;
 import com.kyonggi.diet.member.io.MemberResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 public interface MemberControllerDocs {
     @Operation(summary = "전체 회원 조회", description = "DB에 저장된 모든 회원 정보 조회하는 API")
@@ -17,4 +20,17 @@ public interface MemberControllerDocs {
     @Operation(summary = "특정 회원 1명 조회", description = "회원 ID 값으로 특정 회원 1명의 정보 조회하는 API")
     @Parameter(name = "id", description = "조회를 원하는 회원 ID")
     public MemberResponse getMember(@PathVariable Long id);
+
+    @Operation(summary = "닉네임 유효 확인", description = "해당 닉네임이 유효한지 확인(2~15자의 대소문자 영어 및 한국어 및 숫자 가능), 비속어 불가능, 중복 체크")
+    @Parameter(name = "nickname", description = "닉네임")
+    ResponseEntity<?> checkNickname(
+            @RequestParam String nickname
+    );
+
+    @Operation(summary = "닉네임 업데이트", description = "회원 닉네임 변경")
+    ResponseEntity<?> updateNickname(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody UpdateNicknameRequest request
+
+    );
 }

--- a/src/main/java/com/kyonggi/diet/member/DTO/MemberDTO.java
+++ b/src/main/java/com/kyonggi/diet/member/DTO/MemberDTO.java
@@ -23,6 +23,9 @@ public class MemberDTO {
     @Schema(description = "이름")
     private String name;
 
+    @Schema(description = "닉네임")
+    private String nickname;
+
     @Schema(description = "프로필 URL")
     private String profileUrl;
 

--- a/src/main/java/com/kyonggi/diet/member/DTO/MyPageDTO.java
+++ b/src/main/java/com/kyonggi/diet/member/DTO/MyPageDTO.java
@@ -22,6 +22,9 @@ public class MyPageDTO {
     @Schema(description = "이름")
     private String name;
 
+    @Schema(description = "닉네임")
+    private String nickname;
+
     @Schema(description = "생성일자")
     private String createdAt;
 }

--- a/src/main/java/com/kyonggi/diet/member/DTO/NicknameCheckResponse.java
+++ b/src/main/java/com/kyonggi/diet/member/DTO/NicknameCheckResponse.java
@@ -1,0 +1,11 @@
+package com.kyonggi.diet.member.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NicknameCheckResponse {
+    private boolean available;
+    private String message;
+}

--- a/src/main/java/com/kyonggi/diet/member/DTO/UpdateNicknameRequest.java
+++ b/src/main/java/com/kyonggi/diet/member/DTO/UpdateNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.kyonggi.diet.member.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class UpdateNicknameRequest {
+    private String nickname;
+}

--- a/src/main/java/com/kyonggi/diet/member/MemberEntity.java
+++ b/src/main/java/com/kyonggi/diet/member/MemberEntity.java
@@ -40,6 +40,12 @@ public class MemberEntity {
 
     private String profileUrl;
 
+    @Column(unique = true)
+    private String nickname;
+
+    @Column
+    private Timestamp nicknameUpdatedAt;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private Timestamp createdAt;
@@ -82,6 +88,14 @@ public class MemberEntity {
 
     @OneToMany(mappedBy = "reported")
     private List<Report> reportedBy;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateNicknameUpdatedAt(Timestamp time) {
+        this.nicknameUpdatedAt = time;
+    }
 
     public void updateEmail(String email) {
         this.email = email;

--- a/src/main/java/com/kyonggi/diet/member/MemberRepository.java
+++ b/src/main/java/com/kyonggi/diet/member/MemberRepository.java
@@ -17,4 +17,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     @Query("select m.name from MemberEntity m where m.id = :id")
     String findNameById(@Param("id") Long id);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/kyonggi/diet/member/controller/MemberController.java
+++ b/src/main/java/com/kyonggi/diet/member/controller/MemberController.java
@@ -3,7 +3,9 @@ package com.kyonggi.diet.member.controller;
 import com.kyonggi.diet.auth.Provider;
 import com.kyonggi.diet.auth.util.JwtTokenUtil;
 import com.kyonggi.diet.controllerDocs.MemberControllerDocs;
+import com.kyonggi.diet.member.CustomUserDetails;
 import com.kyonggi.diet.member.DTO.MemberDTO;
+import com.kyonggi.diet.member.DTO.UpdateNicknameRequest;
 import com.kyonggi.diet.member.io.MemberRequest;
 import com.kyonggi.diet.member.io.MemberResponse;
 import com.kyonggi.diet.member.service.MemberService;
@@ -13,9 +15,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
@@ -78,5 +82,37 @@ public class MemberController implements MemberControllerDocs {
         return modelMapper.map(memberRequest, MemberDTO.class);
     }
 
+    @GetMapping("/nickname/check")
+    public ResponseEntity<?> checkNickname(@RequestParam String nickname) {
+        return ResponseEntity.ok(memberService.checkNicknameAvailable(nickname));
+    }
 
+    @PatchMapping("/nickname")
+    public ResponseEntity<?> updateNickname(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody UpdateNicknameRequest request
+
+    ) {
+        try {
+            String nickname = memberService.updateMemberNickname(user.getEmail(), request.getNickname());
+
+            return ResponseEntity.ok(Map.of(
+                    "success", true,
+                    "message", "닉네임 변경 완료: " + nickname
+            ));
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "message", e.getMessage()
+            ));
+
+        } catch (Exception e) {
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
+                    "success", false,
+                    "message", "서버 오류"
+            ));
+        }
+    }
 }

--- a/src/main/java/com/kyonggi/diet/member/service/MemberService.java
+++ b/src/main/java/com/kyonggi/diet/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.kyonggi.diet.member.service;
 import com.kyonggi.diet.auth.Provider;
 import com.kyonggi.diet.member.DTO.MemberDTO;
 import com.kyonggi.diet.member.DTO.MyPageDTO;
+import com.kyonggi.diet.member.DTO.NicknameCheckResponse;
 import com.kyonggi.diet.member.MemberEntity;
 
 import java.util.List;
@@ -41,4 +42,8 @@ public interface MemberService {
     String getNameById(Long id);
 
     Provider getProvider(String email);
+
+    String updateMemberNickname(String email, String nickname);
+
+    NicknameCheckResponse checkNicknameAvailable(String nickname);
 }

--- a/src/main/java/com/kyonggi/diet/member/service/NicknameFilterService.java
+++ b/src/main/java/com/kyonggi/diet/member/service/NicknameFilterService.java
@@ -1,0 +1,82 @@
+package com.kyonggi.diet.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class NicknameFilterService {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String KEY = "banned:nickname";
+    private Set<String> bannedWords = new HashSet<>();
+    private long lastLoadedAt = 0;
+    private static final long TTL = 60 * 1000;
+
+    private void refreshIfNeeded() {
+        long now = System.currentTimeMillis();
+        if (now - lastLoadedAt > TTL) {
+            Set<String> words = redisTemplate.opsForSet().members(KEY);
+            bannedWords = (words != null) ? new HashSet<>(words) : new HashSet<>();
+            lastLoadedAt = now;
+        }
+    }
+
+    public boolean isBanned(String nickname) {
+        refreshIfNeeded();
+
+        String original = nickname.toLowerCase().replaceAll("\\s+", "");
+        String normalized = normalize(nickname);
+        String noNumbers = original.replaceAll("[0-9]", "");
+
+        for (String banned : bannedWords) {
+            String bannedLower = banned.toLowerCase().replaceAll("\\s+", "");
+            String bannedNormalized = normalize(banned);
+            String bannedNoNumbers = bannedLower.replaceAll("[0-9]", "");
+
+            if (original.contains(bannedLower)) {
+                return true;
+            }
+            if (!bannedNormalized.isEmpty() && normalized.contains(bannedNormalized)) {
+                return true;
+            }
+            if (!bannedNormalized.isEmpty() && original.contains(bannedNormalized)) {
+                return true;
+            }
+            if (normalized.contains(bannedLower)) {
+                return true;
+            }
+            if (!noNumbers.isEmpty() && noNumbers.contains(bannedLower)) {
+                return true;
+            }
+            if (!noNumbers.isEmpty() && !bannedNoNumbers.isEmpty() && noNumbers.contains(bannedNoNumbers)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private String normalize(String input) {
+        if (input == null) return "";
+        String result = input.toLowerCase();
+
+        result = result
+                .replace("1", "i")
+                .replace("!", "i")
+                .replace("0", "o")
+                .replace("3", "e")
+                .replace("5", "s")
+                .replace("4", "a");
+
+        if (input.matches(".*[가-힣].*")) {
+            return result.replaceAll("[^가-힣]", "");
+        }
+
+        return result.replaceAll("[^a-z0-9]", "");
+    }
+}

--- a/src/main/java/com/kyonggi/diet/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/kyonggi/diet/member/service/impl/MemberServiceImpl.java
@@ -4,21 +4,25 @@ import com.kyonggi.diet.auth.Provider;
 import com.kyonggi.diet.auth.socialAccount.SocialAccount;
 import com.kyonggi.diet.auth.socialAccount.SocialAccountRepository;
 import com.kyonggi.diet.member.DTO.MemberDTO;
+import com.kyonggi.diet.member.DTO.NicknameCheckResponse;
 import com.kyonggi.diet.member.MemberEntity;
 import com.kyonggi.diet.member.MemberRepository;
-import com.kyonggi.diet.member.service.CustomMembersDetailService;
 import com.kyonggi.diet.member.service.MemberService;
+import com.kyonggi.diet.member.service.NicknameFilterService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 
@@ -36,6 +40,10 @@ public class MemberServiceImpl implements MemberService {
     private final SocialAccountRepository socialAccountRepository;
     private final ModelMapper modelMapper;
     private final PasswordEncoder encoder;
+    private final NicknameFilterService nicknameFilterService;
+
+    private static final Pattern NICKNAME_PATTERN =
+            Pattern.compile("^[a-zA-Z0-9가-힣 ]{2,15}$");
 
     @Override
     public MemberDTO createMember(MemberDTO memberDTO) {
@@ -120,5 +128,87 @@ public class MemberServiceImpl implements MemberService {
         SocialAccount socialAccount = socialAccountRepository.findByMemberId(member.getId()).orElseThrow(
                 () -> new NoSuchElementException("해당 멤버에 대한 소셜 어카운트를 획들학 수 없습니다."));
         return socialAccount.getProvider();
+    }
+
+    private void validateNicknameFormat(String nickname) {
+        if (nickname == null) {
+            throw new IllegalArgumentException("닉네임은 필수입니다.");
+        }
+
+        if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
+            throw new IllegalArgumentException("닉네임 형식이 올바르지 않습니다. (한글, 영어, 숫자, 공백을 포함한 2자 이상 15자 이하)");
+        }
+    }
+
+    private void validateNicknamePolicy(String nickname) {
+
+        if (nickname.trim().isEmpty()) {
+            throw new IllegalArgumentException("닉네임을 입력해주세요.");
+        }
+
+        String noSpace = nickname.replaceAll("\\s+", "");
+
+        if (noSpace.matches("^[ㄱ-ㅎ]+$") || noSpace.matches("^[ㅏ-ㅣ]+$")) {
+            throw new IllegalArgumentException("자음 또는 모음만으로는 닉네임을 만들 수 없습니다.");
+        }
+    }
+
+    private void validateNicknameBanned(String nickname) {
+        if (nicknameFilterService.isBanned(nickname)) {
+            throw new IllegalArgumentException("사용할 수 없는 단어가 포함된 닉네임입니다.");
+        }
+    }
+
+    @Override
+    @Transactional
+    public String updateMemberNickname(String email, String nickname) {
+
+        MemberEntity member = getMemberByEmail(email);
+
+        validateNicknameFormat(nickname);
+        validateNicknameBanned(nickname);
+        validateNicknamePolicy(nickname);
+
+        nickname = nickname.toLowerCase();
+
+        if (member.getNickname().equals(nickname)) {
+            throw new IllegalArgumentException("기존 닉네임과 동일합니다.");
+        }
+
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
+
+        member.updateNickname(nickname);
+        member.updateNicknameUpdatedAt(new Timestamp(System.currentTimeMillis()));
+
+        try {
+            memberRepository.save(member);
+        } catch (DataIntegrityViolationException e) {
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
+
+        return nickname;
+    }
+
+    @Override
+    public NicknameCheckResponse checkNicknameAvailable(String nickname) {
+
+        try {
+            validateNicknameFormat(nickname);
+            validateNicknamePolicy(nickname);
+            validateNicknameBanned(nickname);
+
+            boolean exists = memberRepository.existsByNickname(nickname.toLowerCase());
+
+            if (exists) {
+                return new NicknameCheckResponse(false, "이미 존재하는 닉네임입니다.");
+            }
+
+            return new NicknameCheckResponse(true, "사용 가능한 닉네임입니다.");
+
+        } catch (IllegalArgumentException e) {
+            return new NicknameCheckResponse(false, e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
# 🚨 ISSUE
닉네임 컬럼을 추가한다.

# 🔨 CHANGES
멤버 엔티티에 닉네임 컬럼 추가

해당 api 추가
- 멤버 닉네임 업데이트(헤더 ahthorization)
- 닉네임 중복 확인

# 🪜 ADDITIONAL CONTEXT
